### PR TITLE
Feature: Order confirmation

### DIFF
--- a/features/order_confirmation.feature
+++ b/features/order_confirmation.feature
@@ -8,4 +8,5 @@ Feature: As a Visitor.
   Scenario: Visitor clicks Buy now! and is taken to a order confirmation page with pick-up time.
   When I click "Buy now!"
   Then I should be on the order confirmation page
-  And I should see "Thank you for your order! Your food will be ready for pickup in 30 minutes!"
+  And I should see "Thank you for your order! Your food will be ready for pick up at"
+  And I should see a pick up time

--- a/features/order_confirmation.feature
+++ b/features/order_confirmation.feature
@@ -7,5 +7,5 @@ Feature: As a Visitor.
 
   Scenario: Visitor clicks Buy now! and is taken to a order confirmation page with pick-up time.
   When I click "Buy now!"
-  Then I should be on the order confiramtion page
+  Then I should be on the order confirmation page
   And I should see "Thank you for your order! Your food will be ready for pickup in 30 minutes!"

--- a/features/order_confirmation.feature
+++ b/features/order_confirmation.feature
@@ -1,0 +1,11 @@
+Feature: As a Visitor.
+  In order to know when my order is ready for pick-up.
+  After clicking buy now, I would like to see an order confirmation with estimated pick up time.
+
+  Background:
+  Given I have a dish in my order and I am on the checkout_screen
+
+  Scenario: Visitor clicks Buy now! and is taken to a order confirmation page with pick-up time.
+  When I click "Buy now!"
+  Then I should be on the order confiramtion page
+  And I should see "Thank you for your order! Your food will be ready for pickup in 30 minutes!"

--- a/features/order_confirmation.feature
+++ b/features/order_confirmation.feature
@@ -9,4 +9,4 @@ Feature: As a Visitor.
   When I click "Buy now!"
   Then I should be on the order confirmation page
   And I should see "Thank you for your order! Your food will be ready for pick up at"
-  And I should see a pick up time
+  And I should see a pick up time 30 minutes from now

--- a/features/order_confirmation.feature
+++ b/features/order_confirmation.feature
@@ -3,10 +3,10 @@ Feature: As a Visitor.
   After clicking buy now, I would like to see an order confirmation with estimated pick up time.
 
   Background:
-  Given I have a dish in my order and I am on the checkout_screen
+    Given I have a dish in my order and I am on the checkout_screen
 
   Scenario: Visitor clicks Buy now! and is taken to a order confirmation page with pick-up time.
-  When I click "Buy now!"
-  Then I should be on the order confirmation page
-  And I should see "Thank you for your order! Your food will be ready for pick up at"
-  And I should see a pick up time 30 minutes from now
+    When I click "Buy now!"
+    Then I should be on the order confirmation page
+    And I should see "Thank you for your order! Your food will be ready for pick up at"
+    And I should see a pick up time 30 minutes from now

--- a/features/step_definitions/order_confirmation_steps.rb
+++ b/features/step_definitions/order_confirmation_steps.rb
@@ -19,3 +19,7 @@ end
 Then(/^I should be on the order confirmation page$/) do
   expect(page).to have_current_path('/order_confirmation')
 end
+
+Then(/^I should see a pick up time$/) do
+  expect(page).to have_content (Time.now + 1800).strftime("%H:%M")
+end

--- a/features/step_definitions/order_confirmation_steps.rb
+++ b/features/step_definitions/order_confirmation_steps.rb
@@ -20,6 +20,6 @@ Then(/^I should be on the order confirmation page$/) do
   expect(page).to have_current_path('/order_confirmation')
 end
 
-Then(/^I should see a pick up time$/) do
+Then(/^I should see a pick up time 30 minutes from now$/) do
   expect(page).to have_content (Time.now + 1800).strftime("%H:%M")
 end

--- a/features/step_definitions/order_confirmation_steps.rb
+++ b/features/step_definitions/order_confirmation_steps.rb
@@ -16,6 +16,6 @@ steps %q{
 end
 
 
-Then(/^I should be on the order confiramtion page$/) do
+Then(/^I should be on the order confirmation page$/) do
   expect(page).to have_current_path('/order_confirmation')
 end

--- a/features/step_definitions/order_confirmation_steps.rb
+++ b/features/step_definitions/order_confirmation_steps.rb
@@ -1,0 +1,21 @@
+Given(/^I have a dish in my order and I am on the checkout_screen$/) do
+steps %q{
+  Given the following dishes exists
+    | name        | price  |
+    | "Meatballs" | "8.99" |
+    | "Salad"     | "4.99" |
+    When I am on the index page
+    And I have a dish in my order
+    And I click "Checkout"
+    Then I should be on the Checkout page
+    And I should see "Salad"
+    And I shold see a dish price of "$4.99"
+    And I should see "Total: $4.99"
+    And I should see a "Buy now!" button
+  }
+end
+
+
+Then(/^I should be on the order confiramtion page$/) do
+  expect(page).to have_current_path('/order_confirmation')
+end

--- a/features/step_definitions/order_confirmation_steps.rb
+++ b/features/step_definitions/order_confirmation_steps.rb
@@ -17,7 +17,7 @@ end
 
 
 Then(/^I should be on the order confirmation page$/) do
-  expect(page).to have_current_path('/order_confirmation')
+  expect(page).to have_current_path '/order_confirmation'
 end
 
 Then(/^I should see a pick up time 30 minutes from now$/) do

--- a/lib/controller.rb
+++ b/lib/controller.rb
@@ -64,7 +64,7 @@ class SlowFood < Sinatra::Base
     else
       @current_order.order_items.each do |order_item|
         @total = @total + order_item.dish.price
-        @current_order.amount = @total
+        @current_order.amount = @total.round(2)
       end
       erb :checkout
     end

--- a/lib/controller.rb
+++ b/lib/controller.rb
@@ -87,6 +87,10 @@ class SlowFood < Sinatra::Base
   redirect '/'
 end
 
+  get '/order_confirmation' do
+    erb :order_confirmation
+  end
+
   get '/auth/login' do
     erb :login
   end

--- a/lib/controller.rb
+++ b/lib/controller.rb
@@ -88,6 +88,8 @@ class SlowFood < Sinatra::Base
 end
 
   get '/order_confirmation' do
+    @current_order = Order.get(session[:order_id])
+    @current_order.pickup_time = (Time.now + 1800).strftime("%H:%M")
     erb :order_confirmation
   end
 

--- a/lib/controller.rb
+++ b/lib/controller.rb
@@ -89,7 +89,7 @@ end
 
   get '/order_confirmation' do
     @current_order = Order.get(session[:order_id])
-    @current_order.pickup_time = (Time.now + 1800).strftime("%H:%M")
+    @current_order.pickup_time = (Time.now + 1800)
     erb :order_confirmation
   end
 

--- a/lib/views/checkout.erb
+++ b/lib/views/checkout.erb
@@ -5,5 +5,7 @@
 <p>Total: $<%=@current_order.amount%></p>
 
 <div>
+  <form method="get" action="/order_confirmation">
   <input class="btn btn-primary" type="submit" value="Buy now!">
+  </form>
 </div>

--- a/lib/views/checkout.erb
+++ b/lib/views/checkout.erb
@@ -2,7 +2,7 @@
   <p><%= order_item.dish.name %> - $<%= order_item.dish.price %></p>
 <% end %>
 
-<p>Total: $<%=@current_order.amount%></p>
+<p>Total: $<%= @current_order.amount %></p>
 
 <div>
   <form method="get" action="/order_confirmation">

--- a/lib/views/checkout.erb
+++ b/lib/views/checkout.erb
@@ -6,6 +6,6 @@
 
 <div>
   <form method="get" action="/order_confirmation">
-  <input class="btn btn-primary" type="submit" value="Buy now!">
+    <input class="btn btn-primary" type="submit" value="Buy now!">
   </form>
 </div>

--- a/lib/views/order_confirmation.erb
+++ b/lib/views/order_confirmation.erb
@@ -1,1 +1,1 @@
-<p>Thank you for your order! Your food will be ready for pickup in 30 minutes!</p>
+<p>Thank you for your order! Your food will be ready for pick up at <%=@current_order.pickup_time.strftime("%H:%M")%></p>

--- a/lib/views/order_confirmation.erb
+++ b/lib/views/order_confirmation.erb
@@ -1,0 +1,1 @@
+<p>Thank you for your order! Your food will be ready for pickup in 30 minutes!</p>

--- a/lib/views/order_confirmation.erb
+++ b/lib/views/order_confirmation.erb
@@ -1,1 +1,1 @@
-<p>Thank you for your order! Your food will be ready for pick up at <%= @current_order.pickup_time %></p>
+<p>Thank you for your order! Your food will be ready for pick up at <%= @current_order.pickup_time.strftime("%H:%M") %></p>

--- a/lib/views/order_confirmation.erb
+++ b/lib/views/order_confirmation.erb
@@ -1,1 +1,1 @@
-<p>Thank you for your order! Your food will be ready for pick up at <%=@current_order.pickup_time.strftime("%H:%M")%></p>
+<p>Thank you for your order! Your food will be ready for pick up at <%= @current_order.pickup_time %></p>

--- a/lib/views/protected.erb
+++ b/lib/views/protected.erb
@@ -1,2 +1,2 @@
 <h2>Protected Page</h2>
-<p>Logged in as <%=current_user.username %></p>
+<p>Logged in as <%= current_user.username %></p>


### PR DESCRIPTION
# [Waffle Story](https://waffle.io/CraftAcademy/slow_food_sinatra_nov/cards/583c1488ba4bee19002a93f5)

## Changes proposed in this pull request: 
This pull request will add implementation for a order confirmation page, which the customer will be taken to when clicking Buy now! on the checkout page. This page will give the customer an estimated pickup time which is 30 minutes from the moment the customer clicked buy now.

## What I have learned working on this feature:
- How to add time to a model property.
- How to display that time only using hour/minute.

<img width="490" alt="screen shot 2016-12-04 at 19 38 55" src="https://cloud.githubusercontent.com/assets/22058587/20868336/5ab126a4-ba59-11e6-9b93-62e28a5c4d48.png">

Ready for Review!
